### PR TITLE
rollsum benchmark: Don't measure rng

### DIFF
--- a/rollsum_test.go
+++ b/rollsum_test.go
@@ -1,7 +1,6 @@
 package hashsplit
 
 import (
-	"bufio"
 	"math/rand"
 	"os"
 	"strconv"
@@ -17,21 +16,18 @@ func BenchmarkRollsum(b *testing.B) {
 		seed        = getSeed()
 		src         = rand.NewSource(seed)
 		rnd         = rand.New(src)
-		r           = bufio.NewReader(rnd)
 		rs          = rollsum.New()
 		countZeroes = os.Getenv("BENCHMARK_ROLLSUM_COUNT_ZEROES") == "1"
 		zeroes      [32]int
 	)
 	b.Logf("using seed %d", seed)
 
-	b.ResetTimer()
+	buf := make([]byte, b.N)
+	rnd.Read(buf[:])
 
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c, err := r.ReadByte()
-		if err != nil {
-			b.Fatal(err)
-		}
-		rs.Roll(c)
+		rs.Roll(buf[i])
 		digest := rs.Digest()
 
 		// Would like to call b.StopTimer() here but ran into this bug:


### PR DESCRIPTION
This patch lifts random number generation out of the rollsum benchmark's
inner loop. On my laptop this changes the benchmark's results from ~6.4
ns/op to ~3.0 ns/op, suggesting this benchmark was previously measuring
the performance of package "math/rand" as much as it was rollsum.